### PR TITLE
Fix a dialyzer warning and enable warn_untyped_record

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,6 @@
 {erl_opts, [debug_info,
            warnings_as_errors,
+           warn_untyped_record,
            {parse_transform, lager_transform}]}.
 {eunit_opts, [verbose]}.
 {cover_enabled, true}.

--- a/src/riak_ensemble_manager.erl
+++ b/src/riak_ensemble_manager.erl
@@ -46,11 +46,11 @@
 
 -include_lib("riak_ensemble_types.hrl").
 
--record(state, {version,
+-record(state, {version :: non_neg_integer(),
                 root :: [peer_id()],
                 root_leader :: leader_id(),
-                peers,
-                remote_peers,
+                peers :: [{{ensemble_id(), peer_id()}, pid()}],
+                remote_peers :: [{{ensemble_id(), peer_id()}, pid()}],
                 ensembles :: [{ensemble_id(), ensemble_info()}]
                }).
 

--- a/test/sc.erl
+++ b/test/sc.erl
@@ -7,23 +7,22 @@
 
 %% -define(SINGLE_NODE, true).
 
--record(state, {init = false,
-                num_workers,
-                known,
-                nodes,
-                workers,
-                next_value = 0,
-                acked,
-                wait,
-                partitioned,
-                values}).
+-record(state, {init = false :: boolean(),
+                num_workers :: integer(),
+                known :: list(),
+                nodes :: list(),
+                next_value = 0 :: integer(),
+                acked :: list(),
+                wait :: integer(),
+                partitioned :: true | undefined,
+                values :: list()}).
 
 -ifdef(SINGLE_NODE).
--record(ensemble_info, {mod,
-                        args,
-                        leader,
-                        members,
-                        seq
+-record(ensemble_info, {mod :: module(),
+                        args :: [any()],
+                        leader :: leader_id(),
+                        members :: [peer_id()],
+                        seq :: {integer(), integer()}
                        }).
 -endif.
 


### PR DESCRIPTION
Also, fixes a probable typo.

I didn't understand the purpose behind the maybe_drop, so I ifdefed it out in non-TEST mode.

I'm also not entirely sure that the {} instead of [] was a typo, but it sure looks like one.

cc @jtuple @andrewjstone 
