### PR TITLE
Fix incorrect specification.

### DIFF
--- a/src/riak_ensemble_peer_worker.erl
+++ b/src/riak_ensemble_peer_worker.erl
@@ -42,7 +42,7 @@
 
 %%===================================================================
 
--spec start(ets:eid()) -> {ok, pid()}.
+-spec start(ets:tid()) -> {ok, pid()}.
 start(ETS) ->
     Parent = self(),
     Pid = spawn(fun() ->


### PR DESCRIPTION
Fix an incorrect type specification generating errors when running
dialyzer.
