### PR TITLE
Add ping_quorum and get_peer_info support calls

### DIFF
--- a/include/riak_ensemble_types.hrl
+++ b/include/riak_ensemble_types.hrl
@@ -12,6 +12,8 @@
 -type epoch() :: integer().
 -type seq() :: integer().
 -type vsn() :: {epoch(), seq()}.
+-type peer_info() :: nodedown | undefined | {any(), boolean(), epoch()}.
+
 -type orddict(Key,Val) :: [{Key, Val}].
 -type ordsets(Val) :: [Val].
 


### PR DESCRIPTION
`riak_ensemble_peer:ping_quorum/1` checks an ensemble for an active
quorum, returning the current ensemble leader as well as the list of
peers supporting the current quorum.

`riak_ensemble_manager:get_peer_info/2` returns information about a
given ensemble peer: the peer's current FSM state, if it is or is not
trusted, and it's current epoch.

Sibling pull-request: basho/riak_kv#979
