### PR TITLE
gossip ClusterState to root manager on join/remove

### DIFF
--- a/src/riak_ensemble_root.erl
+++ b/src/riak_ensemble_root.erl
@@ -124,6 +124,7 @@ root_call({join, Node}, Vsn, State) ->
     _ = lager:info("join(Vsn): ~p :: ~p :: ~p", [Vsn, Node, riak_ensemble_state:members(State)]),
     case riak_ensemble_state:add_member(Vsn, Node, State) of
         {ok, State2} ->
+            riak_ensemble_manager:gossip(State2),
             State2;
         error ->
             failed
@@ -132,6 +133,7 @@ root_call({remove, Node}, Vsn, State) ->
     _ = lager:info("remove(Vsn): ~p :: ~p :: ~p", [Vsn, Node, riak_ensemble_state:members(State)]),
     case riak_ensemble_state:del_member(Vsn, Node, State) of
         {ok, State2} ->
+            riak_ensemble_manager:gossip(State2),
             State2;
         error ->
             failed


### PR DESCRIPTION
When a node is newly joined, it is likely ensembles will be manipulated
on the newly joined node. However, future ensemble ops will fail until
the newly joined cluster member has been learned by the root manager on
the next tick. These changes ensure that the gossip happens immediately
on join and remove and prevents spurious errors relating to asynch
gossip, that must be retried. It is just an optimization.

Fixes #12 for join/remove case. Other cases were not changed as the
analysis seems less straightforward, and I'm not sure changes are even
required.
