### PR TITLE
Add handle_down/4 cb for backend behavior

### DIFF
--- a/src/riak_ensemble_backend.erl
+++ b/src/riak_ensemble_backend.erl
@@ -106,6 +106,17 @@
 %% is returned, backend should eventually call {@link pong/1}.
 -callback ping(pid(), state()) -> {ok|async|failed, state()}.
 
+%% Callback to handle `'DOWN'` messages from monitored, backend related
+%% processes. Returns `false` to indicate that this is a reference not
+%% related to the backend. Returns `{ok, state()}` to indicate that the
+%% backend handled the message and that the peer can continue executing as
+%% before. Returns `{reset, state()}` to indicate that in flight requests are
+%% likely to fail and that any thing the peer needs to do to reset itself, such
+%% as restarting workers, should occur.
+-callback handle_down(reference(), pid(), term(), state()) -> false |
+                                                              {ok, state()} |
+                                                              {reset, state()}.
+
 %%===================================================================
 
 start(Mod, Ensemble, Id, Args) ->

--- a/src/riak_ensemble_basic_backend.erl
+++ b/src/riak_ensemble_basic_backend.erl
@@ -35,6 +35,7 @@
 -export([set_obj_epoch/2, set_obj_seq/2, set_obj_value/2]).
 -export([get/3, put/4, tick/5, ping/2]).
 -export([trusted/1, sync_request/2, sync/2]).
+-export([handle_down/4]).
 
 -include_lib("riak_ensemble_types.hrl").
 
@@ -154,6 +155,12 @@ ping(_From, State) ->
     {ok, State}.
 
 trusted(_State) ->
+    false.
+
+%%===================================================================
+
+-spec handle_down(reference(), pid(), term(), state()) -> false.
+handle_down(_Ref, _Pid, _Reason, _State) ->
     false.
 
 %%===================================================================

--- a/src/riak_ensemble_peer.erl
+++ b/src/riak_ensemble_peer.erl
@@ -1591,10 +1591,10 @@ handle_info({'DOWN', Ref, _, Pid, Reason}, StateName,
         false ->
             State2 = maybe_restart_worker(Pid, State),
             {next_state, StateName, State2};
-        {ok, ModState} ->
-            {next_state, StateName, State#state{modstate=ModState}};
-        {reset, ModState} ->
-            State2 = State#state{modstate=ModState},
+        {ok, ModState2} ->
+            {next_state, StateName, State#state{modstate=ModState2}};
+        {reset, ModState2} ->
+            State2 = State#state{modstate=ModState2},
             step_down(State2)
     end;
 handle_info(quorum_timeout, StateName, State) ->


### PR DESCRIPTION
Handle 'DOWN' messages in the peer and callback into the backend
handle_down/4 function.

Part of a fix for basho/riak_kv#985
