### PR TITLE
Avoid crash on remote manager down

### DIFF
--- a/src/riak_ensemble_manager.erl
+++ b/src/riak_ensemble_manager.erl
@@ -272,7 +272,12 @@ count_quorum(Ensemble, Timeout) ->
 
 -spec typed_call(node(), call_msg(), infinity) -> any().
 typed_call(Node, Msg, Timeout) ->
-    gen_server:call({?MODULE, Node}, Msg, Timeout).
+    try
+        gen_server:call({?MODULE, Node}, Msg, Timeout)
+    catch
+        exit:Err ->
+            {error, Err}
+    end.
 
 -spec typed_cast(node() | pid(), cast_msg()) -> ok.
 typed_cast(Pid, Msg) when is_pid(Pid) ->


### PR DESCRIPTION
Convert the exit exception from a gen_server call to a remote manager to
an error code. This makes it more natural to handle the situation.
This fix is related to issue basho/riak#559, to prevent crashing when
operating in mixed clusters where ensembles are not enabled on all
nodes.  It is an alternative solution to basho/riak_core#607. The testing
procedure is the same as for that PR.
