### PR TITLE
Change default for lease_duration config

### DIFF
--- a/src/riak_ensemble_config.erl
+++ b/src/riak_ensemble_config.erl
@@ -32,7 +32,7 @@ tick() ->
 %% the leader time to refresh before expiration, but lower than the follower
 %% timeout.
 lease() ->
-    get_env(lease_duration, tick() * 2 div 3).
+    get_env(lease_duration, tick() * 3 div 2).
 
 %% @doc
 %% This setting determines if leader leases are trusted or not. Trusting the


### PR DESCRIPTION
Change the default to be `ensemble_tick * 2` instead of `ensemble_tick *
2 div 3`. The latter always results in a value smaller than the tick
timeout which would result in ticks firing after leases expired. Fix
this so that we properly use leases and maintain safety.
