### PR TITLE
Enable edoc preprocessing to deal with macros properly

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -13,3 +13,5 @@
    ["c_src/*.c*"],
    [{env, [{"CFLAGS", "$CFLAGS"}]}]
   }]}.
+
+{edoc_opts, [{preprocess, true}]}.


### PR DESCRIPTION
Edoc is unhappy with the `?STATE` macro, e.g.:

```
/src/riak_ensemble_state.erl: at line 53: syntax error before: '{'
edoc: skipping source file './src/riak_ensemble_state.erl': {'EXIT',error}.
```

Enabling preprocessing sidesteps this problem.
