### PR TITLE
Make synctree LevelDB options user-configurable

### DIFF
--- a/src/synctree_leveldb.erl
+++ b/src/synctree_leveldb.erl
@@ -174,8 +174,4 @@ timestamp({Mega, Secs, Micro}) ->
     Mega*1000*1000*1000*1000 + Secs * 1000 * 1000 + Micro.
 
 leveldb_opts() ->
-    [{is_internal_db, true},
-     {write_buffer_size, 4 * 1024 * 1024},
-     {use_bloomfilter, true},
-     {create_if_missing, true}].
-
+    riak_ensemble_config:synctree_leveldb_opts().


### PR DESCRIPTION
This commit makes the LevelDB options used for ensemble synctrees
configurable in app.config.

This commit also uses the randomized write_buffer pattern used elsewhere
in Riak, where the LevelDB write buffer size is set to be a random value
within a given min/max range. Randomizing the write buffer per LevelDB
instance helps protect against multiple instances needing to flush their
write buffers at the same time.
