### PR TITLE
Use explicit 2.0.2 tag for eleveldb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,5 +35,5 @@ $(error "Rebar not found. Please set REBAR variable or update PATH")
 endif
 
 ## Override test after tools.mk; use custom test runner for isolation.
-test:
+test: testdeps
 	bash test/run.sh

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,6 @@ testdeps: deps
 	$(REBAR) -C rebar.test.config get-deps
 	$(REBAR) -C rebar.test.config compile
 
-test: runtests
-
 runtests: testdeps compile
 	bash test/run.sh
 
@@ -36,3 +34,6 @@ ifeq ($(REBAR),)
 $(error "Rebar not found. Please set REBAR variable or update PATH")
 endif
 
+## Override test after tools.mk; use custom test runner for isolation.
+test:
+	bash test/run.sh

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ DIALYZER_FLAGS ?= -Wunmatched_returns -Werror_handling -Wrace_conditions
 
 .PHONY: all compile clean deps test dialyzer typer
 
-all: deps compile xref dialyzer runtests
+all: deps compile
 
 clean:
 	$(REBAR) clean
@@ -19,10 +19,7 @@ testdeps: deps
 	$(REBAR) -C rebar.test.config get-deps
 	$(REBAR) -C rebar.test.config compile
 
-test: failtest
-
-failtest:
-	$(error Do not use 'make test', use 'make runtests')
+test: runtests
 
 runtests: testdeps compile
 	bash test/run.sh

--- a/rebar.config
+++ b/rebar.config
@@ -8,7 +8,7 @@
 {cover_enabled, true}.
 {xref_checks, [undefined_function_calls]}.
 {deps, [{lager, "2.0.3", {git, "git://github.com/basho/lager.git", {tag, "2.0.3"}}},
-        {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {branch, "develop"}}}]}.
+        {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {tag, "2.0.2"}}}]}.
 
 {port_specs,
  [{".*", "priv/riak_ensemble.so",

--- a/test/sc.erl
+++ b/test/sc.erl
@@ -1,6 +1,8 @@
 -module(sc).
 -compile(export_all).
 
+-ifdef(EQC).
+
 -include_lib("eqc/include/eqc.hrl").
 -include_lib("eqc/include/eqc_statem.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -1065,3 +1067,5 @@ wait_until_quorum(Retry, Ensemble, Node) ->
             timer:sleep(100),
             wait_until_quorum(Retry-1, Ensemble, Node)
     end.
+
+-endif.


### PR DESCRIPTION
Instead of pulling the branch, we now pull an explicit tag for eleveldb.
