### PR TITLE
Avoid writing tombstones on notfound reads when possible

### DIFF
--- a/src/riak_ensemble_config.erl
+++ b/src/riak_ensemble_config.erl
@@ -113,6 +113,19 @@ tree_validation() ->
 synchronous_tree_updates() ->
     get_env(synchronous_tree_updates, false).
 
+%% @doc
+%% Determines how long to wait for additional responses to come in on
+%% certain reads that may return notfound. If we receive responses from
+%% every peer in the ensemble, we do not need to write a tombstone for
+%% the notfound key. If set to zero, no additional time will be waited,
+%% but it is still possible we may be able to skip writing the tombstone
+%% if all the responses arrive within a very close window of time.
+%% The default of 1ms should be enough to avoid most tombstones that
+%% would otherwise be created, but a higher value may be specified in
+%% cases where unpredictable latencies necessitate it.
+notfound_read_delay() ->
+    get_env(notfound_read_delay, 1).
+
 get_env(Key, Default) ->
     case application:get_env(riak_ensemble, Key) of
         undefined ->

--- a/src/riak_ensemble_msg.erl
+++ b/src/riak_ensemble_msg.erl
@@ -40,7 +40,7 @@
 
 %%%===================================================================
 
--type required()   :: quorum | other | all.
+-type required()   :: quorum | other | all | all_or_quorum.
 
 -record(msgstate, {awaiting = undefined :: 'undefined' | reqid(),
                    timer    = undefined :: 'undefined' | reference(),
@@ -265,6 +265,11 @@ check_enough(Collect=#collect{id=Id,
                               required=Required,
                               extra=Extra}) ->
     case quorum_met(Replies, Id, Views, Required, Extra) of
+        true when Required =:= all_or_quorum ->
+            %% If we've hit a quorum with all_or_quorum required, then
+            %% we need to wait some additional length of time and see
+            %% if we get replies from all.
+            try_collect_all(Collect);
         true ->
             From ! {Ref, ok, Replies},
             ok;
@@ -272,6 +277,43 @@ check_enough(Collect=#collect{id=Id,
             collect_timeout(Replies, Parent);
         false ->
             collect_replies(Collect)
+    end.
+
+-spec try_collect_all(#collect{}) -> _.
+try_collect_all(Collect=#collect{reqid=ReqId}) ->
+    %% FIXME make this timeout configurable:
+    erlang:send_after(1000, self(), {try_collect_all_timeout, ReqId}),
+    try_collect_all_impl(Collect).
+
+try_collect_all_impl(Collect=#collect{id=Id,
+                                      replies=Replies0,
+                                      parent={From, Ref},
+                                      reqid=ReqId,
+                                      views=Views}) ->
+    receive
+        {'$gen_all_state_event', Event} ->
+            {reply, ReqId, Peer, Reply} = Event,
+            Replies = [{Peer, Reply}|Replies0],
+            case quorum_met(Replies, Id, Views, all) of
+                true ->
+                    %% At this point we should be guaranteed to have already
+                    %% gotten a parent that we can reply to:
+                    ?OUT("Met quorum with Event ~p Replies ~p", [Event, Replies, Views]),
+                    From ! {Ref, ok, Replies};
+                false ->
+                    ?OUT("Got additional message ~p but quorum still not met", [Event]),
+                    try_collect_all(Collect#collect{replies=Replies});
+                nack ->
+                    %% Since we're waiting for all, we may see a nack from even
+                    %% just a single negative response. But, we already know we
+                    %% have a quorum of positive replies, so we can still send
+                    %% back an 'ok' response with the replies we've gotten.
+                    ?OUT("Got a nack! Returning replies so far: ~p", [Replies]),
+                    From ! {Ref, ok, Replies}
+            end;
+        {try_collect_all_timeout, ReqId} ->
+            ?OUT("Timed out waiting for try_collect_all", []),
+            From ! {Ref, ok, Replies0}
     end.
 
 -spec wait_for_quorum(future()) -> {quorum_met, [peer_reply()]} |
@@ -347,6 +389,8 @@ quorum_met(Replies, Id, [Members|Views], Required, Extra) ->
     {Valid, Nacks} = find_valid(Filtered),
     Quorum = case Required of
                  quorum ->
+                     length(Members) div 2 + 1;
+                 all_or_quorum ->
                      length(Members) div 2 + 1;
                  other ->
                      length(Members) div 2 + 1;

--- a/src/riak_ensemble_msg.erl
+++ b/src/riak_ensemble_msg.erl
@@ -281,8 +281,8 @@ check_enough(Collect=#collect{id=Id,
 
 -spec try_collect_all(#collect{}) -> _.
 try_collect_all(Collect=#collect{reqid=ReqId}) ->
-    %% FIXME make this timeout configurable:
-    erlang:send_after(1000, self(), {try_collect_all_timeout, ReqId}),
+    Timeout = riak_ensemble_config:notfound_read_delay(),
+    erlang:send_after(Timeout, self(), {try_collect_all_timeout, ReqId}),
     try_collect_all_impl(Collect).
 
 try_collect_all_impl(Collect=#collect{id=Id,

--- a/src/riak_ensemble_peer.erl
+++ b/src/riak_ensemble_peer.erl
@@ -30,6 +30,7 @@
 -export([join/2, join/3, update_members/3, get_leader/1, backend_pong/1]).
 -export([kget/4, kget/5, kupdate/6, kput_once/5, kover/5, kmodify/6, kdelete/4,
          ksafe_delete/5, obj_value/2, obj_value/3]).
+-export([debug_local_get/2]).
 -export([setup/2]).
 -export([probe/2, election/2, prepare/2, leading/2, following/2,
          probe/3, election/3, prepare/3, leading/3, following/3]).
@@ -321,6 +322,13 @@ local_get(Pid, Key, Timeout) when is_pid(Pid) ->
 -spec local_put(pid(), term(), term(), timeout()) -> fixme().
 local_put(Pid, Key, Obj, Timeout) when is_pid(Pid) ->
     riak_ensemble_router:sync_send_event(Pid, {local_put, Key, Obj}, Timeout).
+
+%% Acts like local_get, but can be used for any peer, not just the leader.
+%% Should only be used for testing purposes, since values obtained via
+%% this function provide no consistency guarantees whatsoever.
+-spec debug_local_get(pid(), term()) -> std_reply().
+debug_local_get(Pid, Key) ->
+    gen_fsm:sync_send_all_state_event(Pid, {debug_local_get, Key}).
 
 %%%===================================================================
 %%% Core Protocol
@@ -1849,6 +1857,9 @@ handle_sync_event(tree_info, _From, StateName, State=#state{tree_trust=Trust,
     TopHash = riak_ensemble_peer_tree:top_hash(Pid),
     Info = {Trust, Ready, TopHash},
     {reply, Info, StateName, State};
+handle_sync_event({debug_local_get, Key}, From, StateName, State) ->
+    State2 = do_local_get(From, Key, State),
+    {next_state, StateName, State2};
 handle_sync_event(_Event, _From, StateName, State) ->
     Reply = ok,
     {reply, Reply, StateName, State}.

--- a/test/TESTS
+++ b/test/TESTS
@@ -12,3 +12,4 @@ synctree_path_test
 lease_test
 ensemble_tests_pure
 replace_members_test
+read_tombstone_test

--- a/test/read_tombstone_test.erl
+++ b/test/read_tombstone_test.erl
@@ -19,9 +19,9 @@ scenario() ->
     ens_test:wait_stable(root),
     application:set_env(riak_ensemble, notfound_read_delay, 3000),
 
-    Ensembles = riak_ensemble_manager:get_members(root),
+    Peers = riak_ensemble_manager:get_members(root),
     Leader = riak_ensemble_manager:get_leader(root),
-    [Follow1, Follow2] = Ensembles -- [Leader],
+    [Follow1, Follow2] = Peers -- [Leader],
 
     ?debugMsg("Running kget on a nonexistent key"),
     {ok, _} = ens_test:kget(<<"test">>),

--- a/test/read_tombstone_test.erl
+++ b/test/read_tombstone_test.erl
@@ -1,0 +1,53 @@
+-module(read_tombstone_test).
+-compile(export_all).
+-include_lib("eunit/include/eunit.hrl").
+
+%% This test specifically targets an optimization in riak_ensemble that is
+%% intended to avoid writing tombstones when possible on reads that return
+%% notfound. Normally reads that return notfound require a tombstone to be
+%% written in case there's a partial write somewhere in the ensemble that
+%% hasn't been read yet. If we wait an extra, say, 1ms though, then it's
+%% very likely we will see replies from every peer in the ensemble, in
+%% which case we can definitively see whether any partial writes exist or
+%% not, and potentially avoid the need to write a tombstone.
+
+run_test_() ->
+    ens_test:run(fun scenario/0).
+
+scenario() ->
+    ens_test:start(3),
+    ens_test:wait_stable(root),
+    application:set_env(riak_ensemble, notfound_read_delay, 3000),
+
+    Ensembles = riak_ensemble_manager:get_members(root),
+    Leader = riak_ensemble_manager:get_leader(root),
+    [Follow1, Follow2] = Ensembles -- [Leader],
+
+    ?debugMsg("Running kget on a nonexistent key"),
+    {ok, _} = ens_test:kget(<<"test">>),
+
+    ?debugMsg("Testing that no peers have tombstones"),
+    ?assert(is_notfound(Leader, <<"test">>)),
+    ?assert(is_notfound(Follow1, <<"test">>)),
+    ?assert(is_notfound(Follow2, <<"test">>)),
+
+    ?debugMsg("Running kget with one member suspended"),
+    application:set_env(riak_ensemble, notfound_read_delay, 0),
+    Peer2Pid = riak_ensemble_manager:get_peer_pid(root, Follow2),
+    erlang:suspend_process(Peer2Pid),
+    {ok, _} = ens_test:kget(<<"test2">>),
+    erlang:resume_process(Peer2Pid),
+
+    ?debugMsg("Testing that active peers have tombstones"),
+    ?assertNot(is_notfound(Leader, <<"test2">>)),
+    ?assertNot(is_notfound(Follow1, <<"test2">>)),
+
+    ok.
+
+%% This can be used to check for tombstones, because if a key
+%% has a tombstone, we'll see an object returned that wraps
+%% the 'notfound' value rather than just the atom 'notfound' alone.
+is_notfound(Member, Key) ->
+    Pid = riak_ensemble_manager:get_peer_pid(root, Member),
+    Res = riak_ensemble_peer:debug_local_get(Pid, Key),
+    Res =:= notfound.


### PR DESCRIPTION
This PR introduces an optimization into riak_ensemble that tries to avoid writing tombstones when possible on reads that return notfound. Normally, reads that return notfound require a tombstone to be written in case there's a partial write somewhere in the ensemble that hasn't been read yet. If we wait an extra, say, 1ms though, then it's very likely we will see replies from every peer in the ensemble, in which case we can definitively see whether any partial writes exist or not, and potentially avoid the need to write a tombstone.
