### PR TITLE
Add namespaced types constant.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ ebin
 .local_dialyzer_plt
 deps/*
 edoc
+.rebar/
+deps.test/*

--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,7 @@
 {erl_opts, [debug_info,
            warnings_as_errors,
            warn_untyped_record,
+           {platform_define, "^[0-9]+", namespaced_types},
            {parse_transform, lager_transform}]}.
 {eunit_opts, [verbose]}.
 {edoc_opts, [preprocess,


### PR DESCRIPTION
Some of Riak's supporting libraries require that namespaced_types be defined if compiling for older versions of Erlang.  (see basho/riak_test#839)
