### PR TITLE
Add error handling and test coverage for subscription callbacks

### DIFF
--- a/src/riak_ensemble_manager.erl
+++ b/src/riak_ensemble_manager.erl
@@ -659,8 +659,16 @@ state_changed(State=#state{ensemble_data=EnsData, cluster_state=CS, subscribers=
                  %% io:format("Should stop: ~p~n", [{Ensemble, Id}]),
                  ok = riak_ensemble_peer_sup:stop_peer(Ensemble, Id)
          end || Change <- PeerChanges],
-    _ = [Callback(CS) || Callback <- Subscribers],
+    _ = [run_subscriber_callback(Callback, CS) || Callback <- Subscribers],
     State#state{ensemble_data=NewEnsData}.
+
+run_subscriber_callback(Callback, CS) ->
+    try Callback(CS)
+    catch
+        Exception ->
+            lager:warning("Callback ~p crashed! Exception: ~p ClusterState: ~p",
+                          [Callback, Exception, CS])
+    end.
 
 -spec request_remote_peers(state()) -> ok.
 request_remote_peers(State=#state{remote_peers=Remote}) ->

--- a/test/TESTS
+++ b/test/TESTS
@@ -13,3 +13,4 @@ lease_test
 ensemble_tests_pure
 replace_members_test
 read_tombstone_test
+subscription_test

--- a/test/subscription_test.erl
+++ b/test/subscription_test.erl
@@ -13,6 +13,7 @@ run_test_() ->
 scenario() ->
     init_tables(),
     ?assertEqual(ok, riak_ensemble_manager:subscribe(fun callback/1)),
+    ?assertEqual(ok, riak_ensemble_manager:subscribe(fun evil_callback/1)),
     CurrentCount = callback_count(),
     riak_ensemble_manager:enable(),
     wait_until_callback_fires(CurrentCount),
@@ -35,6 +36,9 @@ callback_count() ->
 callback(CS) ->
     ets:insert(?TAB, {latest_state, CS}),
     ets:update_counter(?TAB, callback_count, 1).
+
+evil_callback(_CS) ->
+    throw(revenge_of_the_evil_callback).
 
 wait_until_callback_fires(PrevCount) ->
     wait_until_callback_fires(PrevCount, 3000).

--- a/test/subscription_test.erl
+++ b/test/subscription_test.erl
@@ -16,11 +16,17 @@ scenario() ->
     CurrentCount = callback_count(),
     riak_ensemble_manager:enable(),
     wait_until_callback_fires(CurrentCount),
+    State = latest_state(),
+    ?assert(riak_ensemble_state:enabled(State)),
     ok.
 
 init_tables() ->
     ets:new(?TAB, [named_table, public, set]),
     ets:insert(?TAB, {callback_count, 0}).
+
+latest_state() ->
+    [{latest_state, State}] = ets:lookup(?TAB, latest_state),
+    State.
 
 callback_count() ->
     [{callback_count, Count}] = ets:lookup(?TAB, callback_count),

--- a/test/subscription_test.erl
+++ b/test/subscription_test.erl
@@ -1,0 +1,46 @@
+-module(subscription_test).
+-compile(export_all).
+-include_lib("eunit/include/eunit.hrl").
+
+%% This test targets the subscribe/unsubscribe functionality for
+%% receiving notifications of ensemble state changes.
+
+-define(TAB, subscription_test_callback_count).
+
+run_test_() ->
+    ens_test:run(fun scenario/0).
+
+scenario() ->
+    init_tables(),
+    ?assertEqual(ok, riak_ensemble_manager:subscribe(fun callback/1)),
+    CurrentCount = callback_count(),
+    riak_ensemble_manager:enable(),
+    wait_until_callback_fires(CurrentCount),
+    ok.
+
+init_tables() ->
+    ets:new(?TAB, [named_table, public, set]),
+    ets:insert(?TAB, {callback_count, 0}).
+
+callback_count() ->
+    [{callback_count, Count}] = ets:lookup(?TAB, callback_count),
+    Count.
+
+callback(CS) ->
+    ets:insert(?TAB, {latest_state, CS}),
+    ets:update_counter(?TAB, callback_count, 1).
+
+wait_until_callback_fires(PrevCount) ->
+    wait_until_callback_fires(PrevCount, 3000).
+
+wait_until_callback_fires(PrevCount, Retry) ->
+    CurrentCount = callback_count(),
+    if
+        CurrentCount > PrevCount ->
+            ok;
+        Retry =< 0 ->
+            throw(callback_wait_timeout);
+        Retry > 0 ->
+            timer:sleep(10),
+            wait_until_callback_fires(PrevCount, Retry - 1)
+    end.


### PR DESCRIPTION
This PR adds error handling to the riak_ensemble_manager:subscribe call, so that a crash in a callback function will not take down the ensemble manager process with it, and instead will log an error and continue on.

Additionally, these commits add a test suite for testing the subscribe call in general, which (among other things) specifically tests the callback failure case to ensure that no crashes occur.
