### PR TITLE
Replaced erlang:now with erlang:timestamp

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,7 +9,8 @@
 {cover_enabled, true}.
 {xref_checks, [undefined_function_calls]}.
 {deps, [{lager, "(2.1|2.2).*", {git, "git://github.com/basho/lager.git", {tag, "2.2.0"}}},
-        {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {tag, "2.1.0"}}}]}.
+        {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {tag, "2.1.0"}}},
+        {time_compat, ".*", {git, "git://github.com/lasp-lang/time_compat.git", {branch, "master"}}}]}.
 
 {port_specs,
  [{".*", "priv/riak_ensemble.so",

--- a/rebar.config
+++ b/rebar.config
@@ -8,7 +8,7 @@
              {dir, "edoc"}]}.
 {cover_enabled, true}.
 {xref_checks, [undefined_function_calls]}.
-{deps, [{lager, "2.0.3", {git, "git://github.com/basho/lager.git", {tag, "2.0.3"}}},
+{deps, [{lager, "(2.1|2.2).*", {git, "git://github.com/basho/lager.git", {tag, "2.2.0"}}},
         {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {tag, "2.1.0"}}}]}.
 
 {port_specs,

--- a/src/riak_ensemble_manager.erl
+++ b/src/riak_ensemble_manager.erl
@@ -500,7 +500,7 @@ reload_state() ->
 -spec initial_state() -> state().
 initial_state() ->
     ets:insert(?ETS, {enabled, false}),
-    ClusterName = {node(), erlang:now()},
+    ClusterName = {node(), erlang:timestamp()},
     CS = riak_ensemble_state:new(ClusterName),
     State=#state{version=0,
                  ensemble_data=[],

--- a/src/riak_ensemble_manager.erl
+++ b/src/riak_ensemble_manager.erl
@@ -500,7 +500,7 @@ reload_state() ->
 -spec initial_state() -> state().
 initial_state() ->
     ets:insert(?ETS, {enabled, false}),
-    ClusterName = {node(), erlang:timestamp()},
+    ClusterName = {node(), time_compat:timestamp()},
     CS = riak_ensemble_state:new(ClusterName),
     State=#state{version=0,
                  ensemble_data=[],

--- a/src/synctree_leveldb.erl
+++ b/src/synctree_leveldb.erl
@@ -87,7 +87,7 @@ get_path(Opts) ->
     case proplists:get_value(path, Opts) of
         undefined ->
             Base = "/tmp/ST",
-            Name = integer_to_list(timestamp(erlang:now())),
+            Name = integer_to_list(timestamp(erlang:timestamp())),
             filename:join(Base, Name);
         Path ->
             Path

--- a/src/synctree_leveldb.erl
+++ b/src/synctree_leveldb.erl
@@ -87,7 +87,7 @@ get_path(Opts) ->
     case proplists:get_value(path, Opts) of
         undefined ->
             Base = "/tmp/ST",
-            Name = integer_to_list(timestamp(erlang:timestamp())),
+            Name = integer_to_list(time_compat:unique_integer([positive])),
             filename:join(Base, Name);
         Path ->
             Path
@@ -150,9 +150,6 @@ store(Updates, State=?STATE{id=Id, db=DB}) ->
     %% Intentionally ignore errors (TODO: Should we?)
     _ = eleveldb:write(DB, DBUpdates, []),
     State.
-
-timestamp({Mega, Secs, Micro}) ->
-    Mega*1000*1000*1000*1000 + Secs * 1000 * 1000 + Micro.
 
 leveldb_opts() ->
     [{is_internal_db, true},


### PR DESCRIPTION
Replaced erlang:now with erlang:timestamp as erlang:now is deprecated in Erlang 18.
