### PR TITLE
Bump eleveldb to 2.2.14 for Riak 2.2.0 release

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,7 +9,7 @@
 {xref_checks, [undefined_function_calls]}.
 {deps, [
   {lager, "(2.0|2.1|2.2).*", {git, "git://github.com/basho/lager.git", {tag, "2.2.0"}}},
-  {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {branch, "2.1"}}}
+  {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {branch, "2.2"}}}
 ]}.
 
 {port_specs,


### PR DESCRIPTION
Pick up build fixes form leveldb
