### PR TITLE
Update eleveldb to 2.0.18

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -6,7 +6,7 @@
 {cover_enabled, true}.
 {xref_checks, [undefined_function_calls]}.
 {deps, [{lager, "2.0.3", {git, "git://github.com/basho/lager.git", {tag, "2.0.3"}}},
-        {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {tag, "2.0.15"}}}]}.
+        {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {tag, "2.0.18"}}}]}.
 
 {port_specs,
  [{".*", "priv/riak_ensemble.so",


### PR DESCRIPTION
This keeps the eleveldb version in sync with recent updates to riak_core. See basho/riak_core#830.
