### PR TITLE
Bump eleveldb to 2.0.20

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -6,7 +6,7 @@
 {cover_enabled, true}.
 {xref_checks, [undefined_function_calls]}.
 {deps, [{lager, "2.0.3", {git, "git://github.com/basho/lager.git", {tag, "2.0.3"}}},
-        {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {tag, "2.0.19"}}}]}.
+        {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {tag, "2.0.20"}}}]}.
 
 {port_specs,
  [{".*", "priv/riak_ensemble.so",


### PR DESCRIPTION
Running test locally - should be ready to merge soon, but wanted to get the PR out so BuildBot would run. 

This PR updates eleveldb to 2.0.20, which includes some performance improvements and debugging information around iterators.
