### PR TITLE
Update leveldb to 2.0.21 to pick up iterator fixes.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -6,7 +6,7 @@
 {cover_enabled, true}.
 {xref_checks, [undefined_function_calls]}.
 {deps, [{lager, "2.0.3", {git, "git://github.com/basho/lager.git", {tag, "2.0.3"}}},
-        {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {tag, "2.0.20"}}}]}.
+        {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {tag, "2.0.21"}}}]}.
 
 {port_specs,
  [{".*", "priv/riak_ensemble.so",

--- a/rebar.test.config
+++ b/rebar.test.config
@@ -7,5 +7,5 @@
 {xref_checks, [undefined_function_calls]}.
 {deps_dir, "deps.test"}.
 {lib_dirs, ["deps"]}.
-{deps, [{riak_test, ".*", {git, "git://github.com/basho/riak_test", {branch, "master"}}}]}.
+{deps, [{riak_test, ".*", {git, "git://github.com/basho/riak_test", {branch, "riak/2.0"}}}]}.
 


### PR DESCRIPTION
- Also, fix version of riak_test we pull for testing so updates
  to riakc don't break riak_ensemble testing.
