### PR TITLE
Various post-merge fixes

### DIFF
--- a/src/riak_ensemble_config.erl
+++ b/src/riak_ensemble_config.erl
@@ -127,9 +127,4 @@ notfound_read_delay() ->
     get_env(notfound_read_delay, 1).
 
 get_env(Key, Default) ->
-    case application:get_env(riak_ensemble, Key) of
-        undefined ->
-            Default;
-        {_, Val} ->
-            Val
-    end.
+    application:get_env(riak_ensemble, Key, Default).

--- a/src/riak_ensemble_peer.erl
+++ b/src/riak_ensemble_peer.erl
@@ -1858,8 +1858,8 @@ setup({init, Args}, State0=#state{id=Id, ensemble=Ensemble, ets=ETS, mod=Mod}) -
 
 -spec handle_event(_, atom(), state()) -> {next_state, atom(), state()}.
 handle_event({watch_leader_status, Pid}, StateName, State) when node(Pid) =/= node() ->
-    lager:warning("Remote pid ~p not allowed to watch_leader_status on ensemble peer ~p",
-                  [Pid, State#state.id]),
+    lager:debug("Remote pid ~p not allowed to watch_leader_status on ensemble peer ~p",
+                [Pid, State#state.id]),
     {next_state, StateName, State};
 handle_event({watch_leader_status, Pid}, StateName, State = #state{watchers = Watchers}) ->
     case is_watcher(Pid, Watchers) of
@@ -1874,7 +1874,7 @@ handle_event({watch_leader_status, Pid}, StateName, State = #state{watchers = Wa
 handle_event({stop_watching, Pid}, StateName, State = #state{watchers = Watchers}) ->
     case remove_watcher(Pid, Watchers) of
         not_found ->
-            lager:warning("Tried to stop watching for pid ~p, but did not find it in watcher list"),
+            lager:debug("Tried to stop watching for pid ~p, but did not find it in watcher list"),
             {next_state, StateName, State};
         {MRef, NewWatcherList} ->
             erlang:demonitor(MRef, [flush]),

--- a/src/riak_ensemble_peer.erl
+++ b/src/riak_ensemble_peer.erl
@@ -30,7 +30,6 @@
 -export([join/2, join/3, update_members/3, get_leader/1, backend_pong/1]).
 -export([kget/4, kget/5, kupdate/6, kput_once/5, kover/5, kmodify/6, kdelete/4,
          ksafe_delete/5, obj_value/2, obj_value/3]).
--export([debug_local_get/2]).
 -export([setup/2]).
 -export([probe/2, election/2, prepare/2, leading/2, following/2,
          probe/3, election/3, prepare/3, leading/3, following/3]).
@@ -44,6 +43,11 @@
 -export([count_quorum/2, ping_quorum/2, check_quorum/2, force_state/2,
          get_info/1, stable_views/2, tree_info/1,
          watch_leader_status/1, stop_watching/1]).
+
+%% Backdoor for unit testing
+-ifdef(TEST).
+-export([debug_local_get/2]).
+-endif.
 
 %% Exported internal callback functions
 -export([do_kupdate/4, do_kput_once/4, do_kmodify/4]).
@@ -333,12 +337,14 @@ local_get(Pid, Key, Timeout) when is_pid(Pid) ->
 local_put(Pid, Key, Obj, Timeout) when is_pid(Pid) ->
     riak_ensemble_router:sync_send_event(Pid, {local_put, Key, Obj}, Timeout).
 
+-ifdef(TEST).
 %% Acts like local_get, but can be used for any peer, not just the leader.
 %% Should only be used for testing purposes, since values obtained via
 %% this function provide no consistency guarantees whatsoever.
 -spec debug_local_get(pid(), term()) -> std_reply().
 debug_local_get(Pid, Key) ->
     gen_fsm:sync_send_all_state_event(Pid, {debug_local_get, Key}).
+-endif.
 
 %%%===================================================================
 %%% Core Protocol

--- a/test/TESTS
+++ b/test/TESTS
@@ -13,3 +13,4 @@ lease_test
 ensemble_tests_pure
 replace_members_test
 read_tombstone_test
+leadership_watchers

--- a/test/ens_test.erl
+++ b/test/ens_test.erl
@@ -94,3 +94,21 @@ read_until(Key) ->
             timer:sleep(100),
             read_until(Key)
     end.
+
+%% @doc Utility function used to construct test predicates. Retries the
+%%      function `Fun' until it returns `true', or until the maximum
+%%      number of retries is reached.
+wait_until(Fun) when is_function(Fun) ->
+    wait_until(Fun, 50, 100).
+
+wait_until(Fun, Retry, Delay) when Retry > 0 ->
+    Res = Fun(),
+    case Res of
+        true ->
+            ok;
+        _ when Retry == 1 ->
+            {fail, Res};
+        _ ->
+            timer:sleep(Delay),
+            wait_until(Fun, Retry-1, Delay)
+    end.

--- a/test/leadership_watchers.erl
+++ b/test/leadership_watchers.erl
@@ -1,0 +1,67 @@
+-module(leadership_watchers).
+-compile(export_all).
+-include_lib("eunit/include/eunit.hrl").
+
+run_test_() ->
+    ens_test:run(fun scenario/0, 40).
+
+scenario() ->
+    ens_test:start(3),
+    ens_test:wait_stable(root),
+
+    Pid = riak_ensemble_manager:get_leader_pid(root),
+
+    ?assertEqual(0, length(riak_ensemble_peer:get_watchers(Pid))),
+    ?debugMsg("Watching leader"),
+    riak_ensemble_peer:watch_leader_status(Pid),
+    ?assertEqual(1, length(riak_ensemble_peer:get_watchers(Pid))),
+    ?debugMsg("Waiting for is_leading notification"),
+    wait_status(is_leading, Pid),
+
+    ?debugMsg("Stopping watching leader"),
+    riak_ensemble_peer:stop_watching(Pid),
+    ?assertEqual(0, length(riak_ensemble_peer:get_watchers(Pid))),
+
+    ?debugMsg("Starting watching leader again"),
+    riak_ensemble_peer:watch_leader_status(Pid),
+    ?assertEqual(1, length(riak_ensemble_peer:get_watchers(Pid))),
+    wait_status(is_leading, Pid),
+
+    ?debugMsg("Suspending leader, and waiting for new leader to be elected"),
+    erlang:suspend_process(Pid),
+    ens_test:wait_stable(root),
+
+    ?debugMsg("Resuming former leader, and waiting for is_not_leading notification"),
+    erlang:resume_process(Pid),
+    wait_status(is_not_leading, Pid),
+
+    ?debugMsg("Watching leader in external process"),
+    Watcher = spawn_link(fun() -> watcher(Pid) end),
+    wait_until_n_watchers(2, Pid),
+
+    ?debugMsg("Killing external watcher process and checking peer state"),
+    Watcher ! die,
+    wait_until_n_watchers(1, Pid).
+
+wait_status(Status, Pid) ->
+    receive
+        {Status, Pid, _, _, _} ->
+            ok
+    after
+        5000 ->
+            throw(timeout_waiting_for_leader_status)
+    end.
+
+%% Just a fun to spawn a process that will exit when we tell it to, so we
+%% can test that the watcher gets removed from the ensemble peer state when
+%% a watcher process dies.
+watcher(PeerPid) ->
+    riak_ensemble_peer:watch_leader_status(PeerPid),
+    receive
+        die ->
+            ok
+    end.
+
+wait_until_n_watchers(N, Pid) ->
+    WatcherCountCheck = fun() -> N =:= length(riak_ensemble_peer:get_watchers(Pid)) end,
+    ?assertEqual(ok, ens_test:wait_until(WatcherCountCheck)).


### PR DESCRIPTION
This PR follows up on review comments from #105 with several changes to improve code quality:
- We now use application:get_env/3 instead of reimplementing its functionality ourselves
- Some test code in riak_ensemble_peer is now wrapped in `-ifdef(TEST)` macros
- The leadership watching code now uses monitors to detect dead watchers
- There is a new test module for verifying the leadership monitoring functionality
