### PR TITLE
Add support for OTP20 and rebar3.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ edoc
 deps.test/*
 _build
 .rebar3
+priv/
+c_src/

--- a/rebar.config
+++ b/rebar.config
@@ -9,6 +9,7 @@
 {cover_enabled, true}.
 {xref_checks, [undefined_function_calls]}.
 {deps, [
+  gen_fsm_compat,
   {lager, ".*", {git, "git://github.com/erlang-lager/lager.git", {tag, "3.6.1"}}},
   {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {branch, "develop-3.0"}}}
 ]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -3,6 +3,7 @@
   {git,"git://github.com/basho/eleveldb.git",
        {ref,"db361b1a8387262e715b27fbdd9353f00a07302c"}},
   0},
+ {<<"gen_fsm_compat">>,{pkg,<<"gen_fsm_compat">>,<<"0.3.0">>},0},
  {<<"goldrush">>,{pkg,<<"goldrush">>,<<"0.1.9">>},1},
  {<<"lager">>,
   {git,"git://github.com/erlang-lager/lager.git",
@@ -10,5 +11,6 @@
   0}]}.
 [
 {pkg_hash,[
+ {<<"gen_fsm_compat">>, <<"5903549F67D595F58A7101154CBE0FDD46955FBFBE40813F1E53C23A970FF5F4">>},
  {<<"goldrush">>, <<"F06E5D5F1277DA5C413E84D5A2924174182FB108DABB39D5EC548B27424CD106">>}]}
 ].

--- a/src/riak_ensemble_config.erl
+++ b/src/riak_ensemble_config.erl
@@ -18,7 +18,10 @@
 %%
 %% -------------------------------------------------------------------
 -module(riak_ensemble_config).
+
+-compile(nowarn_export_all).
 -compile(export_all).
+
 -include_lib("riak_ensemble_types.hrl").
 
 %% @doc
@@ -51,7 +54,7 @@ follower_timeout() ->
 %% The election timeout used for randomized election.
 election_timeout() ->
     Timeout = follower_timeout(),
-    Timeout + random:uniform(Timeout).
+    Timeout + rand:uniform(Timeout).
 
 %% @doc
 %% The prefollow timeout determines how long a peer waits to hear from the

--- a/src/riak_ensemble_exchange.erl
+++ b/src/riak_ensemble_exchange.erl
@@ -18,6 +18,8 @@
 %%
 %% -------------------------------------------------------------------
 -module(riak_ensemble_exchange).
+
+-compile(nowarn_export_all).
 -compile(export_all).
 
 start_exchange(Ensemble, Peer, Id, Tree, Peers, Views, Trusted) ->
@@ -26,7 +28,7 @@ start_exchange(Ensemble, Peer, Id, Tree, Peers, Views, Trusted) ->
                       perform_exchange(Ensemble, Peer, Id, Tree, Peers, Views, Trusted)
                   catch Class:Reason ->
                           io:format("CAUGHT: ~p/~p~n~p~n", [Class, Reason, erlang:get_stacktrace()]),
-                          gen_fsm:send_event(Peer, exchange_failed)
+                          gen_fsm_compat:send_event(Peer, exchange_failed)
                   end
           end).
 
@@ -49,7 +51,7 @@ perform_exchange(Ensemble, Peer, Id, Tree, Peers, Views, Trusted) ->
         end,
     case RemotePeers of
         failed ->
-            gen_fsm:send_event(Peer, exchange_failed),
+            gen_fsm_compat:send_event(Peer, exchange_failed),
             ok;
         _ ->
             perform_exchange2(Ensemble, Peer, Id, Tree, RemotePeers)
@@ -61,14 +63,14 @@ perform_exchange2(Ensemble, Peer, Id, Tree, RemotePeers) ->
             exchange(Ensemble, Peer, Id, Tree, RemotePeers);
         false ->
             %% io:format(user, "~p: tree_corrupted (perform_exchange2)~n", [Id]),
-            gen_fsm:sync_send_event(Peer, tree_corrupted, infinity)
+            gen_fsm_compat:sync_send_event(Peer, tree_corrupted, infinity)
     end.
 
 exchange(_Ensemble, Peer, _Id, _Tree, []) ->
-    gen_fsm:send_event(Peer, exchange_complete);
+    gen_fsm_compat:send_event(Peer, exchange_complete);
 exchange(Ensemble, Peer, Id, Tree, [RemotePeer|RemotePeers]) ->
     RemotePid = riak_ensemble_manager:get_peer_pid(Ensemble, RemotePeer),
-    RemoteTree = gen_fsm:sync_send_event(RemotePid, tree_pid, infinity),
+    RemoteTree = gen_fsm_compat:sync_send_event(RemotePid, tree_pid, infinity),
     Local = fun(exchange_get, {L,B}) ->
                     exchange_get(L, B, Peer, Tree);
                (start_exchange_level, _) ->
@@ -100,7 +102,7 @@ exchange(Ensemble, Peer, Id, Tree, [RemotePeer|RemotePeers]) ->
 exchange_get(L, B, PeerPid, Tree) ->
     case riak_ensemble_peer_tree:exchange_get(L, B, Tree) of
         corrupted ->
-            gen_fsm:sync_send_event(PeerPid, tree_corrupted, infinity),
+            gen_fsm_compat:sync_send_event(PeerPid, tree_corrupted, infinity),
             throw(corrupted);
         Hashes ->
             Hashes

--- a/src/riak_ensemble_manager.erl
+++ b/src/riak_ensemble_manager.erl
@@ -487,7 +487,7 @@ reload_state() ->
 -spec initial_state() -> state().
 initial_state() ->
     ets:insert(?ETS, {enabled, false}),
-    ClusterName = {node(), erlang:now()},
+    ClusterName = {node(), os:timestamp()},
     CS = riak_ensemble_state:new(ClusterName),
     State=#state{version=0,
                  ensemble_data=[],

--- a/src/riak_ensemble_msg.erl
+++ b/src/riak_ensemble_msg.erl
@@ -85,7 +85,7 @@ send_all(Msg, Id, Peers, Views) ->
 -spec send_all(msg(), peer_id(), peer_pids(), views(), required()) -> msg_state().
 send_all(_Msg, Id, _Peers=[{Id,_}], _Views, _Required) ->
     ?OUT("~p: self-sending~n", [Id]),
-    gen_fsm:send_event(self(), {quorum_met, []}),
+    gen_fsm_compat:send_event(self(), {quorum_met, []}),
     #msgstate{awaiting=undefined, timer=undefined, replies=[], id=Id};
 send_all(Msg, Id, Peers, Views, Required) ->
     ?OUT("~p/~p: sending to ~p: ~p~n", [Id, self(), Peers, Msg]),
@@ -138,7 +138,7 @@ send_request({PeerId, PeerPid}, ReqId, Event) ->
             reply(From, PeerId, nack);
         _ ->
             ?OUT("~p: Sending to ~p: ~p~n", [self(), PeerId, Event]),
-            gen_fsm:send_event(PeerPid, Event)
+            gen_fsm_compat:send_event(PeerPid, Event)
     end.
 
 %%%===================================================================
@@ -172,14 +172,14 @@ send_cast({_PeerId, PeerPid}, Event) ->
             ok;
         _ ->
             ?OUT("~p: Sending to ~p: ~p~n", [self(), _PeerId, Event]),
-            gen_fsm:send_event(PeerPid, Event)
+            gen_fsm_compat:send_event(PeerPid, Event)
     end.
 
 %%%===================================================================
 
 -spec reply(msg_from(), peer_id(), any()) -> ok.
 reply({riak_ensemble_msg, Sender, ReqId}, Id, Reply) ->
-    gen_fsm:send_all_state_event(Sender, {reply, ReqId, Id, Reply}).
+    gen_fsm_compat:send_all_state_event(Sender, {reply, ReqId, Id, Reply}).
 
 %%%===================================================================
 
@@ -349,7 +349,7 @@ add_reply(Peer, Reply, MsgState=#msgstate{timer=Timer}) ->
         true ->
             cancel_timer(Timer),
             {Valid, _Nacks} = find_valid(Replies),
-            gen_fsm:send_event(self(), {quorum_met, Valid}),
+            gen_fsm_compat:send_event(self(), {quorum_met, Valid}),
             MsgState#msgstate{replies=[], awaiting=undefined, timer=undefined};
         false ->
             MsgState#msgstate{replies=Replies};
@@ -361,7 +361,7 @@ add_reply(Peer, Reply, MsgState=#msgstate{timer=Timer}) ->
 -spec quorum_timeout(msg_state()) -> msg_state().
 quorum_timeout(#msgstate{replies=Replies}) ->
     {Valid, _Nacks} = find_valid(Replies),
-    gen_fsm:send_event(self(), {timeout, Valid}),
+    gen_fsm_compat:send_event(self(), {timeout, Valid}),
     #msgstate{awaiting=undefined, timer=undefined, replies=[]}.
 
 %%%===================================================================

--- a/src/riak_ensemble_peer.erl
+++ b/src/riak_ensemble_peer.erl
@@ -21,7 +21,7 @@
 %% TODO: Before PR. Module + other edocs, general cleanup/refactor.
 
 -module(riak_ensemble_peer).
--behaviour(gen_fsm).
+-behaviour(gen_fsm_compat).
 
 -include_lib("riak_ensemble_types.hrl").
 
@@ -54,9 +54,9 @@
 -export([do_kupdate/4, do_kput_once/4, do_kmodify/4]).
 
 -compile({pulse_replace_module,
-          [{gen_fsm, pulse_gen_fsm}]}).
+          [{gen_fsm_compat, pulse_gen_fsm}]}).
 
-%% gen_fsm callbacks
+%% gen_fsm_compat callbacks
 -export([init/1, handle_event/3, handle_sync_event/4, handle_info/3,
          terminate/3, code_change/4]).
 
@@ -154,12 +154,12 @@
 -spec start_link(module(), ensemble_id(), peer_id(), [any()])
                 -> ignore | {error, _} | {ok, pid()}.
 start_link(Mod, Ensemble, Id, Args) ->
-    gen_fsm:start_link(?MODULE, [Mod, Ensemble, Id, Args], []).
+    gen_fsm_compat:start_link(?MODULE, [Mod, Ensemble, Id, Args], []).
 
 -spec start(module(), ensemble_id(), peer_id(), [any()])
            -> ignore | {error, _} | {ok, pid()}.
 start(Mod, Ensemble, Id, Args) ->
-    gen_fsm:start(?MODULE, [Mod, Ensemble, Id, Args], []).
+    gen_fsm_compat:start(?MODULE, [Mod, Ensemble, Id, Args], []).
 
 %% TODO: Do we want this to be routable by ensemble/id instead?
 -spec join(pid(), peer_id()) -> ok | timeout | {error, [{already_member, peer_id()}]}.
@@ -207,33 +207,33 @@ stable_views(Ensemble, Timeout) ->
 
 -spec get_leader(pid()) -> peer_id().
 get_leader(Pid) when is_pid(Pid) ->
-    gen_fsm:sync_send_all_state_event(Pid, get_leader, infinity).
+    gen_fsm_compat:sync_send_all_state_event(Pid, get_leader, infinity).
 
 -spec watch_leader_status(pid()) -> ok.
 watch_leader_status(Pid) when is_pid(Pid) ->
-    gen_fsm:send_all_state_event(Pid, {watch_leader_status, self()}).
+    gen_fsm_compat:send_all_state_event(Pid, {watch_leader_status, self()}).
 
 -spec stop_watching(pid()) -> ok.
 stop_watching(Pid) when is_pid(Pid) ->
-    gen_fsm:send_all_state_event(Pid, {stop_watching, self()}).
+    gen_fsm_compat:send_all_state_event(Pid, {stop_watching, self()}).
 
 -ifdef(TEST).
 -spec get_watchers(pid()) -> [{pid(), reference()}].
 get_watchers(Pid) when is_pid(Pid) ->
-    gen_fsm:sync_send_all_state_event(Pid, get_watchers).
+    gen_fsm_compat:sync_send_all_state_event(Pid, get_watchers).
 -endif.
 
 get_info(Pid) when is_pid(Pid) ->
-    gen_fsm:sync_send_all_state_event(Pid, get_info, infinity).
+    gen_fsm_compat:sync_send_all_state_event(Pid, get_info, infinity).
 
 tree_info(Pid) when is_pid(Pid) ->
-    gen_fsm:sync_send_all_state_event(Pid, tree_info, infinity).
+    gen_fsm_compat:sync_send_all_state_event(Pid, tree_info, infinity).
 
 backend_pong(Pid) when is_pid(Pid) ->
-    gen_fsm:send_event(Pid, backend_pong).
+    gen_fsm_compat:send_event(Pid, backend_pong).
 
 force_state(Pid, EpochSeq) ->
-    gen_fsm:sync_send_event(Pid, {force_state, EpochSeq}).
+    gen_fsm_compat:sync_send_event(Pid, {force_state, EpochSeq}).
 
 %%%===================================================================
 %%% K/V API
@@ -350,7 +350,7 @@ local_put(Pid, Key, Obj, Timeout) when is_pid(Pid) ->
 %% this function provide no consistency guarantees whatsoever.
 -spec debug_local_get(pid(), term()) -> std_reply().
 debug_local_get(Pid, Key) ->
-    gen_fsm:sync_send_all_state_event(Pid, {debug_local_get, Key}).
+    gen_fsm_compat:sync_send_all_state_event(Pid, {debug_local_get, Key}).
 -endif.
 
 %%%===================================================================
@@ -474,7 +474,7 @@ exchange(Msg, State) ->
     common(Msg, State, exchange).
 
 exchange(tree_corrupted, From, State) ->
-    gen_fsm:reply(From, ok),
+    gen_fsm_compat:reply(From, ok),
     repair(init, State);
 exchange(Msg, From, State) ->
     common(Msg, From, State, exchange).
@@ -698,7 +698,7 @@ leading(ping_quorum, From, State=#state{fact=Fact, id=Id, members=Members,
                                         %% io:format("timeout~n"),
                                         Extra
                                 end,
-                       gen_fsm:reply(From, {Id, TreeReady, Result})
+                       gen_fsm_compat:reply(From, {Id, TreeReady, Result})
                end),
     {next_state, leading, State3};
 leading(stable_views, _From, State=#state{fact=Fact}) ->
@@ -863,7 +863,7 @@ following(Msg, From, State) ->
 
 -spec forward(_, fsm_from(), state()) -> {next_state, following, state()}.
 forward(Msg, From, State) ->
-    catch gen_fsm:send_event(peer(leader(State), State), {forward, From, Msg}),
+    catch gen_fsm_compat:send_event(peer(leader(State), State), {forward, From, Msg}),
     {next_state, following, State}.
 
 -spec valid_request(_,_,state()) -> boolean().
@@ -1027,13 +1027,13 @@ common(Msg, State, StateName) ->
 -spec common(_, fsm_from(), state(), StateName) -> {next_state, StateName, state()}.
 common({force_state, {Epoch, Seq}}, From, State, StateName) ->
     State2 = set_epoch(Epoch, set_seq(Seq, State)),
-    gen_fsm:reply(From, ok),
+    gen_fsm_compat:reply(From, ok),
     {next_state, StateName, State2};
 common(tree_pid, From, State, StateName) ->
-    gen_fsm:reply(From, State#state.tree),
+    gen_fsm_compat:reply(From, State#state.tree),
     {next_state, StateName, State};
 common(tree_corrupted, From, State, StateName) ->
-    gen_fsm:reply(From, ok),
+    gen_fsm_compat:reply(From, ok),
     lager:debug("~p: tree_corrupted in state ~p", [State#state.id, StateName]),
     repair(init, State);
 common(_Msg, From, State, StateName) ->
@@ -1363,7 +1363,7 @@ send_reply(From, Reply) ->
         nack -> ok;
         {ok,_} -> ok
     end,
-    gen_fsm:reply(From, Reply),
+    gen_fsm_compat:reply(From, Reply),
     ok.
 
 do_put_fsm(Key, Fun, Args, From, Self, State=#state{tree=Tree}) ->
@@ -1371,7 +1371,7 @@ do_put_fsm(Key, Fun, Args, From, Self, State=#state{tree=Tree}) ->
         corrupted ->
             %% io:format("Tree corrupted (put)!~n"),
             send_reply(From, failed),
-            gen_fsm:sync_send_event(Self, tree_corrupted, infinity);
+            gen_fsm_compat:sync_send_event(Self, tree_corrupted, infinity);
         KnownHash ->
             do_put_fsm(Key, Fun, Args, From, Self, KnownHash, State)
     end.
@@ -1383,7 +1383,7 @@ do_put_fsm(Key, Fun, Args, From, Self, KnownHash, State) ->
     case is_current(Local, Key, KnownHash, State2) of
         local_timeout ->
             %% TODO: Should this send a request_failed?
-            %% gen_fsm:sync_send_event(Self, request_failed, infinity),
+            %% gen_fsm_compat:sync_send_event(Self, request_failed, infinity),
             send_reply(From, unavailable);
         true ->
             do_modify_fsm(Key, Local, Fun, Args, From, State2);
@@ -1393,9 +1393,9 @@ do_put_fsm(Key, Fun, Args, From, Self, KnownHash, State) ->
                     do_modify_fsm(Key, Current, Fun, Args, From, State2);
                 {corrupted, _State2} ->
                     send_reply(From, failed),
-                    gen_fsm:sync_send_event(Self, tree_corrupted, infinity);
+                    gen_fsm_compat:sync_send_event(Self, tree_corrupted, infinity);
                 {failed, _State3} ->
-                    gen_fsm:sync_send_event(Self, request_failed, infinity),
+                    gen_fsm_compat:sync_send_event(Self, request_failed, infinity),
                     send_reply(From, unavailable)
             end
     end.
@@ -1407,11 +1407,11 @@ do_modify_fsm(Key, Current, Fun, Args, From, State=#state{self=Self}) ->
             send_reply(From, {ok, New});
         {corrupted, _State2} ->
             send_reply(From, failed),
-            gen_fsm:sync_send_event(Self, tree_corrupted, infinity);
+            gen_fsm_compat:sync_send_event(Self, tree_corrupted, infinity);
         {precondition, _State2} ->
             send_reply(From, failed);
         {failed, _State2} ->
-            gen_fsm:sync_send_event(Self, request_failed, infinity),
+            gen_fsm_compat:sync_send_event(Self, request_failed, infinity),
             send_reply(From, timeout)
     end.
 
@@ -1425,9 +1425,9 @@ do_overwrite_fsm(Key, Val, From, Self, State0=#state{ets=ETS}) ->
             send_reply(From, {ok, Result});
         {corrupted, _State2} ->
             send_reply(From, timeout),
-            gen_fsm:sync_send_event(Self, tree_corrupted, infinity);
+            gen_fsm_compat:sync_send_event(Self, tree_corrupted, infinity);
         {failed, _State2} ->
-            gen_fsm:sync_send_event(Self, request_failed, infinity),
+            gen_fsm_compat:sync_send_event(Self, request_failed, infinity),
             send_reply(From, timeout)
     end.
 
@@ -1437,7 +1437,7 @@ do_get_fsm(Key, From, Self, Opts, State=#state{tree=Tree}) ->
         corrupted ->
             %% io:format("Tree corrupted (get)!~n"),
             send_reply(From, failed),
-            gen_fsm:sync_send_event(Self, tree_corrupted, infinity);
+            gen_fsm_compat:sync_send_event(Self, tree_corrupted, infinity);
         KnownHash ->
             do_get_fsm(Key, From, Self, KnownHash, Opts, State)
     end.
@@ -1452,7 +1452,7 @@ do_get_fsm(Key, From, Self, KnownHash, Opts, State0) ->
     case is_current(Local, Key, KnownHash, State) of
         local_timeout ->
             %% TODO: Should this send a request_failed?
-            %% gen_fsm:sync_send_event(Self, request_failed, infinity),
+            %% gen_fsm_compat:sync_send_event(Self, request_failed, infinity),
             send_reply(From, timeout);
         true ->
             case LocalOnly of
@@ -1464,7 +1464,7 @@ do_get_fsm(Key, From, Self, KnownHash, Opts, State0) ->
                             %% TODO: If there's a new leader, we could forward
                             %%       instead of timeout.
                             send_reply(From, timeout),
-                            gen_fsm:sync_send_event(Self, request_failed, infinity)
+                            gen_fsm_compat:sync_send_event(Self, request_failed, infinity)
                     end;
                 false ->
                     case get_latest_obj(Key, Local, KnownHash, State) of
@@ -1482,11 +1482,11 @@ do_get_fsm(Key, From, Self, KnownHash, Opts, State0) ->
                     send_reply(From, {ok, Current});
                 {corrupted, _State2} ->
                     send_reply(From, failed),
-                    gen_fsm:sync_send_event(Self, tree_corrupted, infinity);
+                    gen_fsm_compat:sync_send_event(Self, tree_corrupted, infinity);
                 {failed, _State2} ->
                     %% TODO: Should this be failed or unavailable?
                     send_reply(From, failed),
-                    gen_fsm:sync_send_event(Self, request_failed, infinity)
+                    gen_fsm_compat:sync_send_event(Self, request_failed, infinity)
             end
     end.
 
@@ -1675,7 +1675,7 @@ put_obj(Key, Obj, Seq, State=#state{id=Id, members=Members, self=Self}) ->
     case local_put(Self, Key, Obj2, ?LOCAL_PUT_TIMEOUT) of
         failed ->
             lager:warning("Failed local_put for Key ~p, Id = ~p", [Key, Id]),
-            gen_fsm:sync_send_event(Self, request_failed, infinity),
+            gen_fsm_compat:sync_send_event(Self, request_failed, infinity),
             {failed, State2};
         Local ->
             case wait_for_quorum(Future) of
@@ -1811,16 +1811,12 @@ get_value(Obj, Default, State) ->
     end.
 
 %%%===================================================================
-%%% gen_fsm callbacks
+%%% gen_fsm_compat callbacks
 %%%===================================================================
 
 -spec init([any(),...]) -> {ok, setup, state()}.
 init([Mod, Ensemble, Id, Args]) ->
     lager:debug("~p: starting peer", [Id]),
-    {A,B,C} = os:timestamp(),
-    _ = random:seed(A + erlang:phash2(Id),
-                    B + erlang:phash2(node()),
-                    C),
     ETS = ets:new(x, [public, {read_concurrency, true}, {write_concurrency, true}]),
     TreeTrust = case riak_ensemble_config:tree_validation() of
                     false ->
@@ -1835,7 +1831,7 @@ init([Mod, Ensemble, Id, Args]) ->
                    tree_trust=TreeTrust,
                    alive=?ALIVE,
                    mod=Mod},
-    gen_fsm:send_event(self(), {init, Args}),
+    gen_fsm_compat:send_event(self(), {init, Args}),
     riak_ensemble_peer_sup:register_peer(Ensemble, Id, self(), ETS),
     {ok, setup, State}.
 
@@ -2230,13 +2226,13 @@ save_fact(#state{ensemble=Ensemble, id=Id, fact=Fact}) ->
 -spec set_timer(non_neg_integer(), any(), state()) -> state().
 set_timer(Time, Event, State) ->
     State2 = cancel_timer(State),
-    Timer = gen_fsm:send_event_after(Time, Event),
+    Timer = gen_fsm_compat:send_event_after(Time, Event),
     State2#state{timer=Timer}.
 
 -spec cancel_timer(state()) -> state().
 cancel_timer(State=#state{timer=undefined}) ->
     State;
 cancel_timer(State=#state{timer=Timer}) ->
-    %% Note: gen_fsm cancel_timer discards timer message if already sent
-    catch gen_fsm:cancel_timer(Timer),
+    %% Note: gen_fsm_compat cancel_timer discards timer message if already sent
+    catch gen_fsm_compat:cancel_timer(Timer),
     State#state{timer=undefined}.

--- a/src/riak_ensemble_peer_tree.erl
+++ b/src/riak_ensemble_peer_tree.erl
@@ -209,7 +209,7 @@ code_change(_OldVsn, State, _Extra) ->
 
 %% Hardcoded to send FSM event as expected by riak_ensemble_peer
 async_reply(From, Reply) when is_pid(From) ->
-    gen_fsm:send_event(From, Reply).
+    gen_fsm_compat:send_event(From, Reply).
 
 -spec do_get(_,state()) -> {any(), state()}.
 do_get(Key, State=#state{tree=Tree}) ->

--- a/src/riak_ensemble_router.erl
+++ b/src/riak_ensemble_router.erl
@@ -38,12 +38,15 @@
 %% additional concurrency and not have a single router bottleneck traffic.
 %%
 %% A secondary purpose of this module is to provide an isolated version
-%% of `gen_fsm:send_sync_event' that converts timeouts into error tuples
+%% of `gen_fsm_compat:send_sync_event' that converts timeouts into error tuples
 %% rather than exit conditions, as well as discarding late/delayed messages.
 %% This isolation is provided by spawning an intermediary proxy process.
 
 -module(riak_ensemble_router).
+
+-compile(nowarn_export_all).
 -compile(export_all).
+
 -behaviour(gen_server).
 
 -include_lib("riak_ensemble_types.hrl").
@@ -95,7 +98,7 @@ sync_proxy(From, Ref, Node, Target, Event, Timeout) ->
 -spec sync_proxy_direct(pid(), reference(), pid(), msg(), timeout()) -> ok.
 sync_proxy_direct(From, Ref, Pid, Event, Timeout) ->
     try
-        Result = gen_fsm:sync_send_event(Pid, Event, Timeout),
+        Result = gen_fsm_compat:sync_send_event(Pid, Event, Timeout),
         From ! {Ref, Result},
         ok
     catch
@@ -235,7 +238,7 @@ ensemble_cast(Ensemble, Msg) ->
 handle_ensemble_cast({sync_send_event, From, Ref, Event, Timeout}, Pid) ->
     spawn(fun() ->
                   try
-                      Result = gen_fsm:sync_send_event(Pid, Event, Timeout),
+                      Result = gen_fsm_compat:sync_send_event(Pid, Event, Timeout),
                       From ! {Ref, Result}
                   catch
                       _:_ ->

--- a/src/riak_ensemble_test.erl
+++ b/src/riak_ensemble_test.erl
@@ -17,7 +17,10 @@
 %% under the License.
 %%
 %% -------------------------------------------------------------------
+
 -module(riak_ensemble_test).
+
+-compile(nowarn_export_all).
 -compile(export_all).
 
 -define(ETS_TEST, riak_ensemble_test).

--- a/src/riak_ensemble_util.erl
+++ b/src/riak_ensemble_util.erl
@@ -148,7 +148,7 @@ shuffle(L=[_]) ->
     L;
 shuffle(L) ->
     Range = length(L),
-    L2 = [{random:uniform(Range), E} || E <- L],
+    L2 = [{rand:uniform(Range), E} || E <- L],
     [E || {_, E} <- lists:sort(L2)].
 
 %% Copied from riak_core_send_msg.erl

--- a/src/synctree_leveldb.erl
+++ b/src/synctree_leveldb.erl
@@ -87,7 +87,7 @@ get_path(Opts) ->
     case proplists:get_value(path, Opts) of
         undefined ->
             Base = "/tmp/ST",
-            Name = integer_to_list(timestamp(erlang:now())),
+            Name = integer_to_list(timestamp(os:timestamp())),
             filename:join(Base, Name);
         Path ->
             Path


### PR DESCRIPTION
* Switch to gen_fsm_compat.
* Use os:timestamp where possible.
* Don't warn on explicit export_all usage.